### PR TITLE
Add label account to values.yaml file to work with multiple local users.

### DIFF
--- a/argo-cd/values.yaml
+++ b/argo-cd/values.yaml
@@ -179,7 +179,8 @@ configs:
 
     # -- Enable local user
     accounts.lpadgett: apiKey, login
-    accounts.lpadgett.enabled: "true"
+
+    accounts.jabel: apiKey, login
 
     # -- Enable Pipeline user
     accounts.gitops-ci: apiKey


### PR DESCRIPTION
Add value to add jabel i.e. josh abel to the argo cd install. This will be good for practicing adding roles to local users with casbin via a self managed argo cd helm chart.