### PR TITLE
Add user lpadgett (me) to the argocd installation.

### DIFF
--- a/argo-cd/kustomize/patches/argocd-cm.yaml
+++ b/argo-cd/kustomize/patches/argocd-cm.yaml
@@ -4,3 +4,4 @@ metadata:
   name: argocd-cm
 data:
   timeout.reconciliation: 300s
+  accounts.lpadgett: apiKey, login


### PR DESCRIPTION
edit configmap file to add lpadgett as a user with appropriate limited rights.